### PR TITLE
Don't hard-code threshold below which resize ops are ignored

### DIFF
--- a/Silica/SIAccessibilityElement.h
+++ b/Silica/SIAccessibilityElement.h
@@ -113,7 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param frame The frame to move the element to.
  *  @param threshold The size difference (from curent size) below which resize requests will be ignored
  */
-- (void)setFrame:(CGRect)frame withThreshold:(uint)threshold;
+- (void)setFrame:(CGRect)frame withThreshold:(CGSize)threshold;
 
 /**
  *  Updates the position of the accessibility element.

--- a/Silica/SIAccessibilityElement.h
+++ b/Silica/SIAccessibilityElement.h
@@ -104,6 +104,18 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setFrame:(CGRect)frame;
 
 /**
+ *  Updates the frame of the accessibility element.
+ *
+ *  Updates the frame of the accessibility element to match the input frame as closely as possible given known parameters.
+ *
+ *  The frame's size will be ignored if its difference from the current frame is below the given threshold.
+ *
+ *  @param frame The frame to move the element to.
+ *  @param threshold The size difference (from curent size) below which resize requests will be ignored
+ */
+- (void)setFrame:(CGRect)frame withThreshold:(uint)threshold;
+
+/**
  *  Updates the position of the accessibility element.
  *
  *  @param position The point to move the accessibility element to.

--- a/Silica/SIAccessibilityElement.m
+++ b/Silica/SIAccessibilityElement.m
@@ -154,11 +154,16 @@
 
 - (void)setFrame:(CGRect)frame {
     // We only want to set the size if the size has actually changed.
+    [self setFrame:frame withThreshold:25];
+}
+
+- (void)setFrame:(CGRect)frame withThreshold:(uint)threshold {
+        // We only want to set the size if the size has actually changed.
     BOOL shouldSetSize = YES;
     CGRect currentFrame = self.frame;
     if (self.isResizable) {
-        if (fabs(currentFrame.size.width - frame.size.width) < 25) {
-            if (fabs(currentFrame.size.height - frame.size.height) < 25) {
+        if (fabs(currentFrame.size.width - frame.size.width) < threshold) {
+            if (fabs(currentFrame.size.height - frame.size.height) < threshold) {
                 shouldSetSize = NO;
             }
         }

--- a/Silica/SIAccessibilityElement.m
+++ b/Silica/SIAccessibilityElement.m
@@ -158,16 +158,12 @@
 }
 
 - (void)setFrame:(CGRect)frame withThreshold:(CGSize)threshold {
-    // We only want to set the size if the size has actually changed.
-    BOOL shouldSetSize = NO;
+    // We only want to set the size if the size has actually changed more than a given amount.
     CGRect currentFrame = self.frame;
-    if (self.isResizable) {
-        if (fabs(currentFrame.size.width - frame.size.width) >= threshold.width) {
-            if (fabs(currentFrame.size.height - frame.size.height) >= threshold.height) {
-                shouldSetSize = YES;
-            }
-        }
-    }
+    BOOL shouldSetSize = self.isResizable
+        && (fabs(currentFrame.size.width - frame.size.width) >= threshold.width
+        ||  fabs(currentFrame.size.height - frame.size.height) >= threshold.height);
+
 
     // We set the size before and after setting the position because the
     // accessibility APIs are really finicky with setting size.

--- a/Silica/SIAccessibilityElement.m
+++ b/Silica/SIAccessibilityElement.m
@@ -153,22 +153,20 @@
 }
 
 - (void)setFrame:(CGRect)frame {
-    // We only want to set the size if the size has actually changed.
-    [self setFrame:frame withThreshold:25];
+    CGSize threshold = { .width = 25, .height = 25 };
+    [self setFrame:frame withThreshold:threshold];
 }
 
-- (void)setFrame:(CGRect)frame withThreshold:(uint)threshold {
-        // We only want to set the size if the size has actually changed.
-    BOOL shouldSetSize = YES;
+- (void)setFrame:(CGRect)frame withThreshold:(CGSize)threshold {
+    // We only want to set the size if the size has actually changed.
+    BOOL shouldSetSize = NO;
     CGRect currentFrame = self.frame;
     if (self.isResizable) {
-        if (fabs(currentFrame.size.width - frame.size.width) < threshold) {
-            if (fabs(currentFrame.size.height - frame.size.height) < threshold) {
-                shouldSetSize = NO;
+        if (fabs(currentFrame.size.width - frame.size.width) >= threshold.width) {
+            if (fabs(currentFrame.size.height - frame.size.height) >= threshold.height) {
+                shouldSetSize = YES;
             }
         }
-    } else {
-        shouldSetSize = NO;
     }
 
     // We set the size before and after setting the position because the


### PR DESCRIPTION
Silica currently hard-codes an arbitrary threshold, below which resize operations are ignored.

This patch doesn't remove the hard-coded functionality, it just exposes a separate function that accepts the threshold as a parameter.